### PR TITLE
Try+Optional overhead benchmark

### DIFF
--- a/problems/src/test/java/org/fundamentals/fp/OptionalBenchmark.java
+++ b/problems/src/test/java/org/fundamentals/fp/OptionalBenchmark.java
@@ -1,0 +1,50 @@
+package org.fundamentals.fp;
+
+import static io.vavr.control.Option.none;
+
+import io.vavr.control.Option;
+import io.vavr.control.Try;
+import java.net.URL;
+import javax.annotation.Nullable;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.profile.GCProfiler;
+import org.openjdk.jmh.results.format.ResultFormatType;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+@State(Scope.Thread) @Fork(1)
+@Warmup(iterations = 3, time = 3)
+@Measurement(iterations = 5, time = 5)
+public class OptionalBenchmark {
+    private URL url;
+    @Setup public void prepare() throws Exception { url = new URL("http://localhost:1234");}
+    @TearDown public void cleanUp() { url = null;}
+
+    @Benchmark public Try<Option<URL>> using_try_optional() {
+        return Try.of(() -> url).map(Option::some).onFailure(Throwable::printStackTrace).recover(ex -> none());
+    }
+
+    @Benchmark public Try<URL> using_try() {
+        return Try.of(() -> url).onFailure(Throwable::printStackTrace).recover(ex -> null);
+    }
+
+    @Benchmark public @Nullable URL using_nullable() {
+        try { return url; } catch (Exception ex) { ex.printStackTrace(); return null; }
+    }
+
+    public static void main(String[] args) throws Exception {
+        new Runner(new OptionsBuilder()
+                .include(OptionalBenchmark.class.getName())
+                .resultFormat(ResultFormatType.JSON)
+                .result("target/jmh-results-optional.json")
+                .addProfiler(GCProfiler.class)
+                .build()).run();
+    }
+}


### PR DESCRIPTION
```
Benchmark                                                           Mode  Cnt          Score          Error   Units
OptionalBenchmark.using_nullable                                   thrpt    5  339562950.964 ± 15606175.571   ops/s
OptionalBenchmark.using_nullable:·gc.alloc.rate                    thrpt    5         ≈ 10⁻⁴                 MB/sec
OptionalBenchmark.using_nullable:·gc.alloc.rate.norm               thrpt    5         ≈ 10⁻⁷                   B/op
OptionalBenchmark.using_nullable:·gc.count                         thrpt    5            ≈ 0                 counts
OptionalBenchmark.using_try                                        thrpt    5  190674685.529 ± 19209760.748   ops/s
OptionalBenchmark.using_try:·gc.alloc.rate                         thrpt    5       2644.106 ±      266.855  MB/sec
OptionalBenchmark.using_try:·gc.alloc.rate.norm                    thrpt    5         16.000 ±        0.001    B/op
OptionalBenchmark.using_try:·gc.churn.G1_Eden_Space                thrpt    5       2657.738 ±      276.765  MB/sec
OptionalBenchmark.using_try:·gc.churn.G1_Eden_Space.norm           thrpt    5         16.082 ±        0.269    B/op
OptionalBenchmark.using_try:·gc.churn.G1_Old_Gen                   thrpt    5          0.003 ±        0.006  MB/sec
OptionalBenchmark.using_try:·gc.churn.G1_Old_Gen.norm              thrpt    5         ≈ 10⁻⁵                   B/op
OptionalBenchmark.using_try:·gc.count                              thrpt    5        230.000                 counts
OptionalBenchmark.using_try:·gc.time                               thrpt    5        145.000                     ms
OptionalBenchmark.using_try_optional                               thrpt    5  139484109.891 ±  4805521.130   ops/s
OptionalBenchmark.using_try_optional:·gc.alloc.rate                thrpt    5       3867.406 ±      131.473  MB/sec
OptionalBenchmark.using_try_optional:·gc.alloc.rate.norm           thrpt    5         32.000 ±        0.001    B/op
OptionalBenchmark.using_try_optional:·gc.churn.G1_Eden_Space       thrpt    5       3883.416 ±      125.693  MB/sec
OptionalBenchmark.using_try_optional:·gc.churn.G1_Eden_Space.norm  thrpt    5         32.133 ±        0.192    B/op
OptionalBenchmark.using_try_optional:·gc.churn.G1_Old_Gen          thrpt    5          0.007 ±        0.009  MB/sec
OptionalBenchmark.using_try_optional:·gc.churn.G1_Old_Gen.norm     thrpt    5         ≈ 10⁻⁴                   B/op
OptionalBenchmark.using_try_optional:·gc.count                     thrpt    5        327.000                 counts
OptionalBenchmark.using_try_optional:·gc.time                      thrpt    5        203.000                     ms
```